### PR TITLE
🚑  Forward client routing in production

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 dotenv.config();
 
+import path from "path";
 import express from "express";
 const app = express();
 const { PORT = 3000 } = process.env;
@@ -10,6 +11,11 @@ app.use("/storybook", express.static("dist/storybook"));
 
 // Serve app production bundle
 app.use(express.static("dist/app"));
+
+// Handle client routing, return all requests to the app
+app.get("*", (_req, res) => {
+  res.sendFile(path.join(__dirname, "app/index.html"));
+});
 
 app.get("/", (_req, res) => {
   res.send("Hello World!");


### PR DESCRIPTION
On production (Heroku deployment or npm start), it's not possible to directly go to routes like /register.
This pull request fixes this issue and forwards all routes to the client.